### PR TITLE
Merge missing versions & cleanup

### DIFF
--- a/rdpwrap.ini
+++ b/rdpwrap.ini
@@ -1883,32 +1883,6 @@ SLInitHook.x64=1
 SLInitOffset.x64=22C80
 SLInitFunc.x64=New_CSLQuery_Initialize
 
-[10.0.14393.3503]
-LocalOnlyPatch.x86=1
-LocalOnlyOffset.x86=A6528
-LocalOnlyCode.x86=jmpshort
-LocalOnlyPatch.x64=1
-LocalOnlyOffset.x64=8D931
-LocalOnlyCode.x64=jmpshort
-SingleUserPatch.x86=1
-SingleUserOffset.x86=36C65
-SingleUserCode.x86=nop
-SingleUserPatch.x64=1
-SingleUserOffset.x64=1B6A4
-SingleUserCode.x64=Zero
-DefPolicyPatch.x86=1
-DefPolicyOffset.x86=31189
-DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
-DefPolicyPatch.x64=1
-DefPolicyOffset.x64=F185
-DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
-SLInitHook.x86=1
-SLInitOffset.x86=458A2
-SLInitFunc.x86=New_CSLQuery_Initialize
-SLInitHook.x64=1
-SLInitOffset.x64=22C80
-SLInitFunc.x64=New_CSLQuery_Initialize
-
 [10.0.14393.3383]
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=A6578
@@ -1930,6 +1904,32 @@ DefPolicyOffset.x64=F185
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
 SLInitHook.x86=1
 SLInitOffset.x86=45912
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22C80
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.14393.3503]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A6528
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=8D931
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=36C65
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1B6A4
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=31189
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=F185
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=458A2
 SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=22C80
@@ -4041,14 +4041,6 @@ SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=1ACDC
 SLInitFunc.x64=New_CSLQuery_Initialize
-bInitialized.x64 =ECAB0
-bServerSku.x64 =ECAB4
-lMaxUserSessions.x64 =ECAB8
-bAppServerAllowed.x64 =ECAC0
-bRemoteConnAllowed.x64=ECAC4
-bMultimonAllowed.x64 =ECAC8
-ulMaxDebugSessions.x64=ECACC
-bFUSEnabled.x64 =ECAD0
 
 [10.0.17763.771]
 LocalOnlyPatch.x86=1
@@ -5806,7 +5798,6 @@ bMultimonAllowed.x86  =A22B8
 bServerSku.x86        =A22BC
 ulMaxDebugSessions.x86=A22C0
 bRemoteConnAllowed.x86=A22C4
-
 bFUSEnabled.x64       =C4490
 lMaxUserSessions.x64  =C4494
 bAppServerAllowed.x64 =C4498
@@ -5825,7 +5816,6 @@ bMultimonAllowed.x86  =C02B8
 bServerSku.x86        =C02BC
 ulMaxDebugSessions.x86=C02C0
 bRemoteConnAllowed.x86=C02C4
-
 bServerSku.x64        =E6494
 ulMaxDebugSessions.x64=E6498
 bRemoteConnAllowed.x64=E649C
@@ -5844,7 +5834,6 @@ bMultimonAllowed.x86  =C12B8
 bServerSku.x86        =C12BC
 ulMaxDebugSessions.x86=C12C0
 bRemoteConnAllowed.x86=C12C4
-
 bServerSku.x64        =E4494
 ulMaxDebugSessions.x64=E4498
 bRemoteConnAllowed.x64=E449C
@@ -5863,7 +5852,6 @@ bMultimonAllowed.x86  =D3078
 bServerSku.x86        =D307C
 ulMaxDebugSessions.x86=D3080
 bRemoteConnAllowed.x86=D3084
-
 bFUSEnabled.x64       =F9054
 lMaxUserSessions.x64  =F9058
 bAppServerAllowed.x64 =F905C
@@ -5882,7 +5870,6 @@ bMultimonAllowed.x86  =D3078
 bServerSku.x86        =D307C
 ulMaxDebugSessions.x86=D3080
 bRemoteConnAllowed.x86=D3084
-
 bFUSEnabled.x64       =F9054
 lMaxUserSessions.x64  =F9058
 bAppServerAllowed.x64 =F905C
@@ -5901,7 +5888,6 @@ bMultimonAllowed.x86  =D3078
 bServerSku.x86        =D307C
 ulMaxDebugSessions.x86=D3080
 bRemoteConnAllowed.x86=D3084
-
 bFUSEnabled.x64       =FA054
 lMaxUserSessions.x64  =FA058
 bAppServerAllowed.x64 =FA05C
@@ -5920,7 +5906,6 @@ bMultimonAllowed.x86  =D3078
 bServerSku.x86        =D307C
 ulMaxDebugSessions.x86=D3080
 bRemoteConnAllowed.x86=D3084
-
 bFUSEnabled.x64       =FA054
 lMaxUserSessions.x64  =FA058
 bAppServerAllowed.x64 =FA05C
@@ -5939,7 +5924,6 @@ bMultimonAllowed.x86  =D3078
 bServerSku.x86        =D307C
 ulMaxDebugSessions.x86=D3080
 bRemoteConnAllowed.x86=D3084
-
 bFUSEnabled.x64       =FA054
 lMaxUserSessions.x64  =FA058
 bAppServerAllowed.x64 =FA05C
@@ -5958,7 +5942,6 @@ bMultimonAllowed.x86  =D4078
 bServerSku.x86        =D407C
 ulMaxDebugSessions.x86=D4080
 bRemoteConnAllowed.x86=D4084
-
 bFUSEnabled.x64       =FA054
 lMaxUserSessions.x64  =FA058
 bAppServerAllowed.x64 =FA05C
@@ -6005,7 +5988,6 @@ bMultimonAllowed.x86  =BFA00
 bServerSku.x86        =BFA04
 ulMaxDebugSessions.x86=BFA08
 bRemoteConnAllowed.x86=BFA0C
-
 bFUSEnabled.x64       =ECFF8
 lMaxUserSessions.x64  =ECFFC
 bAppServerAllowed.x64 =ED000
@@ -6024,7 +6006,6 @@ bMultimonAllowed.x86  =BF7F0
 bServerSku.x86        =BF7F4
 ulMaxDebugSessions.x86=BF7F8
 bRemoteConnAllowed.x86=BF7FC
-
 bFUSEnabled.x64       =ECBD8
 lMaxUserSessions.x64  =ECBDC
 bAppServerAllowed.x64 =ECBE0
@@ -6043,7 +6024,6 @@ bMultimonAllowed.x86  =C27E8
 bServerSku.x86        =C27EC
 ulMaxDebugSessions.x86=C27F0
 bRemoteConnAllowed.x86=C27F4
-
 bFUSEnabled.x64       =EDBF0
 lMaxUserSessions.x64  =EDBF4
 bAppServerAllowed.x64 =EDBF8
@@ -6062,7 +6042,6 @@ bMultimonAllowed.x86  =C17E8
 bServerSku.x86        =C17EC
 ulMaxDebugSessions.x86=C17F0
 bRemoteConnAllowed.x86=C17F4
-
 bFUSEnabled.x64       =EEBF0
 lMaxUserSessions.x64  =EEBF4
 bAppServerAllowed.x64 =EEBF8
@@ -6081,7 +6060,6 @@ bMultimonAllowed.x86  =C5F70
 bServerSku.x86        =C5F74
 ulMaxDebugSessions.x86=C5F78
 bRemoteConnAllowed.x86=C5F7C
-
 bFUSEnabled.x64       =F3448
 lMaxUserSessions.x64  =F344C
 bAppServerAllowed.x64 =F3450
@@ -6100,7 +6078,6 @@ bMultimonAllowed.x86  =C3F70
 bServerSku.x86        =C3F74
 ulMaxDebugSessions.x86=C3F78
 bRemoteConnAllowed.x86=C3F7C
-
 zlMaxUserSessions.x64  =F23B0
 lMaxUserSessions.x64  =F23B0
 bAppServerAllowed.x64 =F23B4
@@ -6120,7 +6097,6 @@ bMultimonAllowed.x86  =C3F98
 bServerSku.x86        =C3F9C
 ulMaxDebugSessions.x86=C3FA0
 bRemoteConnAllowed.x86=C3FA4
-
 lMaxUserSessions.x64  =F23B0
 bAppServerAllowed.x64 =F23B4
 bServerSku.x64        =F23B8
@@ -6139,7 +6115,6 @@ bMultimonAllowed.x86  =C4F98
 bServerSku.x86        =C4F9C
 ulMaxDebugSessions.x86=C4FA0
 bRemoteConnAllowed.x86=C4FA4
-
 lMaxUserSessions.x64  =F23B0
 bAppServerAllowed.x64 =F23B4
 bServerSku.x64        =F23B8
@@ -6169,7 +6144,6 @@ bRemoteConnAllowed.x86=C3FA4
 bMultimonAllowed.x86  =C3F98
 ulMaxDebugSessions.x86=C3FA0
 bFUSEnabled.x86       =C3F88
-
 lMaxUserSessions.x64  =F13B0
 bAppServerAllowed.x64 =F13B4
 bServerSku.x64        =F13B8
@@ -6198,7 +6172,6 @@ bMultimonAllowed.x86  =C3F70
 bServerSku.x86        =C3F74
 ulMaxDebugSessions.x86=C3F78
 bRemoteConnAllowed.x86=C3F7C
-
 lMaxUserSessions.x64  =F23B0
 bAppServerAllowed.x64 =F23B4
 bServerSku.x64        =F23B8
@@ -6217,7 +6190,6 @@ bMultimonAllowed.x86  =C3F70
 bServerSku.x86        =C3F74
 ulMaxDebugSessions.x86=C3F78
 bRemoteConnAllowed.x86=C3F7C
-
 lMaxUserSessions.x64  =F23B0
 bAppServerAllowed.x64 =F23B4
 bServerSku.x64        =F23B8
@@ -6236,7 +6208,6 @@ bMultimonAllowed.x86  =C3F70
 bServerSku.x86        =C3F74
 ulMaxDebugSessions.x86=C3F78
 bRemoteConnAllowed.x86=C3F7C
-
 lMaxUserSessions.x64  =F23B0
 bAppServerAllowed.x64 =F23B4
 bServerSku.x64        =F23B8
@@ -6255,7 +6226,6 @@ bRemoteConnAllowed.x86=C1F6C
 bMultimonAllowed.x86  =C1F70
 ulMaxDebugSessions.x86=C1F74
 bFUSEnabled.x86       =C1F78
-
 bInitialized.x64      =F2430
 bRemoteConnAllowed.x64=F2434
 bMultimonAllowed.x64  =F2438
@@ -6274,7 +6244,6 @@ bRemoteConnAllowed.x86=C1F6C
 bMultimonAllowed.x86  =C1F70
 ulMaxDebugSessions.x86=C1F74
 bFUSEnabled.x86       =C1F78
-
 bInitialized.x64      =F2430
 bRemoteConnAllowed.x64=F2434
 bMultimonAllowed.x64  =F2438
@@ -6293,7 +6262,6 @@ bRemoteConnAllowed.x86=C0F6C
 bMultimonAllowed.x86  =C0F70
 ulMaxDebugSessions.x86=C0F74
 bFUSEnabled.x86       =C0F78
-
 bServerSku.x64        =EF3C0
 lMaxUserSessions.x64  =EF3C4
 bAppServerAllowed.x64 =EF3C8
@@ -6312,7 +6280,6 @@ bRemoteConnAllowed.x86=C0F6C
 bMultimonAllowed.x86  =C0F70
 ulMaxDebugSessions.x86=C0F74
 bFUSEnabled.x86       =C0F78
-
 bServerSku.x64        =EF3C0
 lMaxUserSessions.x64  =EF3C4
 bAppServerAllowed.x64 =EF3C8
@@ -6331,7 +6298,6 @@ bRemoteConnAllowed.x86=C0F6C
 bMultimonAllowed.x86  =C0F70
 ulMaxDebugSessions.x86=C0F74
 bFUSEnabled.x86       =C0F78
-
 bServerSku.x64        =E73C0
 lMaxUserSessions.x64  =E73C4
 bAppServerAllowed.x64 =E73C8
@@ -6360,7 +6326,6 @@ bRemoteConnAllowed.x86=C4F68
 bMultimonAllowed.x86  =C4F6C
 ulMaxDebugSessions.x86=C4F70
 bFUSEnabled.x86       =C4F74
-
 bServerSku.x64        =E93C0
 lMaxUserSessions.x64  =E93C4
 bAppServerAllowed.x64 =E93C8
@@ -6379,7 +6344,6 @@ bRemoteConnAllowed.x86=C4F68
 bMultimonAllowed.x86  =C4F6C
 ulMaxDebugSessions.x86=C4F70
 bFUSEnabled.x86       =C4F74
-
 bServerSku.x64        =E93C0
 lMaxUserSessions.x64  =E93C4
 bAppServerAllowed.x64 =E93C8
@@ -6398,7 +6362,6 @@ bRemoteConnAllowed.x86=C4F68
 bMultimonAllowed.x86  =C4F6C
 ulMaxDebugSessions.x86=C4F70
 bFUSEnabled.x86       =C4F74
-
 bServerSku.x64        =E93C0
 lMaxUserSessions.x64  =E93C4
 bAppServerAllowed.x64 =E93C8
@@ -6417,7 +6380,6 @@ bRemoteConnAllowed.x86=C4F68
 bMultimonAllowed.x86  =C4F6C
 ulMaxDebugSessions.x86=C4F70
 bFUSEnabled.x86       =C4F74
-
 bInitialized.x64      =E9430
 bRemoteConnAllowed.x64=E9434
 bMultimonAllowed.x64  =E9438
@@ -6436,7 +6398,6 @@ bRemoteConnAllowed.x86=C0F6C
 bMultimonAllowed.x86  =C0F70
 ulMaxDebugSessions.x86=C0F74
 bFUSEnabled.x86       =C0F78
-
 bServerSku.x64        =E73C0
 lMaxUserSessions.x64  =E73C4
 bAppServerAllowed.x64 =E73C8
@@ -6455,7 +6416,6 @@ bRemoteConnAllowed.x86=C4F78
 bMultimonAllowed.x86  =C4F7C
 ulMaxDebugSessions.x86=C4F80
 bFUSEnabled.x86       =C4F84
-
 bServerSku.x64        =E93E0
 lMaxUserSessions.x64  =E93E4
 bAppServerAllowed.x64 =E93E8
@@ -6474,7 +6434,6 @@ bRemoteConnAllowed.x86=C4F78
 bMultimonAllowed.x86  =C4F7C
 ulMaxDebugSessions.x86=C4F80
 bFUSEnabled.x86       =C4F84
-
 bServerSku.x64        =E93E0
 lMaxUserSessions.x64  =E93E4
 bAppServerAllowed.x64 =E93E8
@@ -6493,7 +6452,6 @@ bRemoteConnAllowed.x86=C3F78
 bMultimonAllowed.x86  =C3F7C
 ulMaxDebugSessions.x86=C3F80
 bFUSEnabled.x86       =C3F84
-
 bInitialized.x64      =EA460
 bRemoteConnAllowed.x64=EA464
 bMultimonAllowed.x64  =EA468
@@ -6512,7 +6470,6 @@ bRemoteConnAllowed.x86=C3F78
 bMultimonAllowed.x86  =C3F7C
 ulMaxDebugSessions.x86=C3F80
 bFUSEnabled.x86       =C3F84
-
 bInitialized.x64      =EA460
 bRemoteConnAllowed.x64=EA464
 bMultimonAllowed.x64  =EA468
@@ -6531,7 +6488,6 @@ bRemoteConnAllowed.x86=C3F78
 bMultimonAllowed.x86  =C3F7C
 ulMaxDebugSessions.x86=C3F80
 bFUSEnabled.x86       =C3F84
-
 bInitialized.x64      =EA460
 bRemoteConnAllowed.x64=EA464
 bMultimonAllowed.x64  =EA468
@@ -6550,7 +6506,6 @@ bRemoteConnAllowed.x86=C3F78
 bMultimonAllowed.x86  =C3F7C
 ulMaxDebugSessions.x86=C3F80
 bFUSEnabled.x86       =C3F84
-
 bInitialized.x64      =EA460
 bRemoteConnAllowed.x64=EA464
 bMultimonAllowed.x64  =EA468
@@ -6569,7 +6524,6 @@ bRemoteConnAllowed.x86=C1F7C
 bMultimonAllowed.x86  =C1F80
 ulMaxDebugSessions.x86=C1F84
 bFUSEnabled.x86       =C1F88
-
 bServerSku.x64        =E73D0
 lMaxUserSessions.x64  =E73D4
 bAppServerAllowed.x64 =E73D8
@@ -6588,7 +6542,6 @@ bRemoteConnAllowed.x86=C1F7C
 bMultimonAllowed.x86  =C1F80
 ulMaxDebugSessions.x86=C1F84
 bFUSEnabled.x86       =C1F88
-
 bServerSku.x64        =E73D0
 lMaxUserSessions.x64  =E73D4
 bAppServerAllowed.x64 =E73D8
@@ -6617,7 +6570,6 @@ bRemoteConnAllowed.x86=C1F7C
 bMultimonAllowed.x86  =C1F80
 ulMaxDebugSessions.x86=C1F84
 bFUSEnabled.x86       =C1F88
-
 bServerSku.x64        =E73D0
 lMaxUserSessions.x64  =E73D4
 bAppServerAllowed.x64 =E73D8
@@ -6636,7 +6588,6 @@ bRemoteConnAllowed.x86=C1FA4
 bMultimonAllowed.x86  =C1FA8
 ulMaxDebugSessions.x86=C1FAC
 bFUSEnabled.x86       =C1FB0
-
 bServerSku.x64        =E73D0
 lMaxUserSessions.x64  =E73D4
 bAppServerAllowed.x64 =E73D8
@@ -6666,7 +6617,6 @@ bRemoteConnAllowed.x86=C2FA4
 bMultimonAllowed.x86  =C2FA8
 ulMaxDebugSessions.x86=C2FAC
 bFUSEnabled.x86       =C2FB0
-
 bServerSku.x64        =E73D0
 lMaxUserSessions.x64  =E73D4
 bAppServerAllowed.x64 =E73D8
@@ -6685,7 +6635,6 @@ bRemoteConnAllowed.x86=C2FA4
 bMultimonAllowed.x86  =C2FA8
 ulMaxDebugSessions.x86=C2FAC
 bFUSEnabled.x86       =C2FB0
-
 bServerSku.x64        =E73D0
 lMaxUserSessions.x64  =E73D4
 bAppServerAllowed.x64 =E73D8
@@ -6704,7 +6653,6 @@ bRemoteConnAllowed.x86=C2FA4
 bMultimonAllowed.x86  =C2FA8
 ulMaxDebugSessions.x86=C2FAC
 bFUSEnabled.x86       =C2FB0
-
 bServerSku.x64        =E73D0
 lMaxUserSessions.x64  =E73D4
 bAppServerAllowed.x64 =E73D8
@@ -6723,7 +6671,6 @@ bRemoteConnAllowed.x86=C2FA4
 bMultimonAllowed.x86  =C2FA8
 ulMaxDebugSessions.x86=C2FAC
 bFUSEnabled.x86       =C2FB0
-
 bServerSku.x64        =E73D0
 lMaxUserSessions.x64  =E73D4
 bAppServerAllowed.x64 =E73D8
@@ -6742,7 +6689,6 @@ bRemoteConnAllowed.x86=C2FA4
 bMultimonAllowed.x86  =C2FA8
 ulMaxDebugSessions.x86=C2FAC
 bFUSEnabled.x86       =C2FB0
-
 bServerSku.x64        =E73D0
 lMaxUserSessions.x64  =E73D4
 bAppServerAllowed.x64 =E73D8
@@ -6761,7 +6707,6 @@ bRemoteConnAllowed.x86=C1FA4
 bMultimonAllowed.x86  =C1FA8
 ulMaxDebugSessions.x86=C1FAC
 bFUSEnabled.x86       =C1FB0
-
 bServerSku.x64        =E63D0
 lMaxUserSessions.x64  =E63D4
 bAppServerAllowed.x64 =E63D8
@@ -6800,7 +6745,6 @@ bRemoteConnAllowed.x86=C1F7C
 bMultimonAllowed.x86  =C1F80
 ulMaxDebugSessions.x86=C1F84
 bFUSEnabled.x86       =C1F88
-
 bServerSku.x64        =E73D0
 lMaxUserSessions.x64  =E73D4
 bAppServerAllowed.x64 =E73D8
@@ -6819,7 +6763,6 @@ bRemoteConnAllowed.x86=C1F7C
 bMultimonAllowed.x86  =C1F80
 ulMaxDebugSessions.x86=C1F84
 bFUSEnabled.x86       =C1F88
-
 bServerSku.x64        =E73D0
 lMaxUserSessions.x64  =E73D4
 bAppServerAllowed.x64 =E73D8
@@ -6838,7 +6781,6 @@ bRemoteConnAllowed.x86=C4F7C
 bMultimonAllowed.x86  =C4F80
 ulMaxDebugSessions.x86=C4F84
 bFUSEnabled.x86       =C4F88
-
 bServerSku.x64        =E93D0
 lMaxUserSessions.x64  =E93D4
 bAppServerAllowed.x64 =E93D8
@@ -6857,7 +6799,6 @@ bRemoteConnAllowed.x86=C4F7C
 bMultimonAllowed.x86  =C4F80
 ulMaxDebugSessions.x86=C4F84
 bFUSEnabled.x86       =C4F88
-
 bServerSku.x64        =E93D0
 lMaxUserSessions.x64  =E93D4
 bAppServerAllowed.x64 =E93D8
@@ -6876,7 +6817,6 @@ bRemoteConnAllowed.x86=C1F7C
 bMultimonAllowed.x86  =C1F80
 ulMaxDebugSessions.x86=C1F84
 bFUSEnabled.x86       =C1F88
-
 bServerSku.x64        =E63D0
 lMaxUserSessions.x64  =E63D4
 bAppServerAllowed.x64 =E63D8
@@ -6895,7 +6835,6 @@ bRemoteConnAllowed.x86=C0F7C
 bMultimonAllowed.x86  =C0F80
 ulMaxDebugSessions.x86=C0F84
 bFUSEnabled.x86       =C0F88
-
 bInitialized.x64      =E8460
 bRemoteConnAllowed.x64=E8464
 bMultimonAllowed.x64  =E8468
@@ -6914,7 +6853,6 @@ bRemoteConnAllowed.x86=C0F7C
 bMultimonAllowed.x86  =C0F80
 ulMaxDebugSessions.x86=C0F84
 bFUSEnabled.x86       =C0F88
-
 bInitialized.x64      =EC460
 bRemoteConnAllowed.x64=EC464
 bMultimonAllowed.x64  =EC468
@@ -6933,7 +6871,6 @@ bRemoteConnAllowed.x86=C0F7C
 bMultimonAllowed.x86  =C0F80
 ulMaxDebugSessions.x86=C0F84
 bFUSEnabled.x86       =C0F88
-
 bInitialized.x64      =EC460
 bRemoteConnAllowed.x64=EC464
 bMultimonAllowed.x64  =EC468
@@ -6952,7 +6889,6 @@ bRemoteConnAllowed.x86=C5F78
 bMultimonAllowed.x86  =C5F7C
 ulMaxDebugSessions.x86=C5F80
 bFUSEnabled.x86       =C5F84
-
 bServerSku.x64        =EF3D0
 lMaxUserSessions.x64  =EF3D4
 bAppServerAllowed.x64 =EF3D8
@@ -6971,7 +6907,6 @@ bRemoteConnAllowed.x86=C5F78
 bMultimonAllowed.x86  =C5F7C
 ulMaxDebugSessions.x86=C5F80
 bFUSEnabled.x86       =C5F84
-
 bServerSku.x64        =EF3D0
 lMaxUserSessions.x64  =EF3D4
 bAppServerAllowed.x64 =EF3D8
@@ -6990,7 +6925,6 @@ bRemoteConnAllowed.x86=C4F78
 bMultimonAllowed.x86  =C4F7C
 ulMaxDebugSessions.x86=C4F80
 bFUSEnabled.x86       =C4F84
-
 bServerSku.x64        =EE3D0
 lMaxUserSessions.x64  =EE3D4
 bAppServerAllowed.x64 =EE3D8
@@ -7009,7 +6943,6 @@ bRemoteConnAllowed.x86=C5F78
 bMultimonAllowed.x86  =C5F7C
 ulMaxDebugSessions.x86=C5F80
 bFUSEnabled.x86       =C5F84
-
 bInitialized.x64      =EF460
 bRemoteConnAllowed.x64=EF464
 bMultimonAllowed.x64  =EF468
@@ -7028,7 +6961,6 @@ bRemoteConnAllowed.x86=C5F78
 bMultimonAllowed.x86  =C5F7C
 ulMaxDebugSessions.x86=C5F80
 bFUSEnabled.x86       =C5F84
-
 bServerSku.x64        =EE3C0
 lMaxUserSessions.x64  =EE3C4
 bAppServerAllowed.x64 =EE3C8
@@ -7047,7 +6979,6 @@ bRemoteConnAllowed.x86=C5F78
 bMultimonAllowed.x86  =C5F7C
 ulMaxDebugSessions.x86=C5F80
 bFUSEnabled.x86       =C5F84
-
 bServerSku.x64        =EE3C0
 lMaxUserSessions.x64  =EE3C4
 bAppServerAllowed.x64 =EE3C8
@@ -7076,7 +7007,6 @@ bRemoteConnAllowed.x86=C6F84
 bMultimonAllowed.x86  =C6F88
 ulMaxDebugSessions.x86=C6F8C
 bFUSEnabled.x86       =C6F90
-
 bServerSku.x64        =F0408
 lMaxUserSessions.x64  =F040C
 bAppServerAllowed.x64 =F0410
@@ -7095,7 +7025,6 @@ bRemoteConnAllowed.x86=C6F84
 bMultimonAllowed.x86  =C6F88
 ulMaxDebugSessions.x86=C6F8C
 bFUSEnabled.x86       =C6F90
-
 bServerSku.x64        =F0408
 lMaxUserSessions.x64  =F040C
 bAppServerAllowed.x64 =F0410
@@ -7114,7 +7043,6 @@ bRemoteConnAllowed.x86=C6F84
 bMultimonAllowed.x86  =C6F88
 ulMaxDebugSessions.x86=C6F8C
 bFUSEnabled.x86       =C6F90
-
 bServerSku.x64        =F0408
 lMaxUserSessions.x64  =F040C
 bAppServerAllowed.x64 =F0410
@@ -7133,7 +7061,6 @@ bRemoteConnAllowed.x86=C5F78
 bMultimonAllowed.x86  =C5F7C
 ulMaxDebugSessions.x86=C5F80
 bFUSEnabled.x86       =C5F84
-
 bServerSku.x64        =ECBDC
 lMaxUserSessions.x64  =ECBE0
 bAppServerAllowed.x64 =ECBE4
@@ -7162,7 +7089,6 @@ bRemoteConnAllowed.x86=C2F7C
 bMultimonAllowed.x86  =C2F80
 ulMaxDebugSessions.x86=C2F84
 bFUSEnabled.x86       =C2F88
-
 bServerSku.x64        =E93E0
 lMaxUserSessions.x64  =E93E4
 bAppServerAllowed.x64 =E93E8
@@ -7181,7 +7107,6 @@ bRemoteConnAllowed.x86=C2F7C
 bMultimonAllowed.x86  =C2F80
 ulMaxDebugSessions.x86=C2F84
 bFUSEnabled.x86       =C2F88
-
 bServerSku.x64        =E93E0
 lMaxUserSessions.x64  =E93E4
 bAppServerAllowed.x64 =E93E8
@@ -7200,7 +7125,6 @@ bRemoteConnAllowed.x86=C4F28
 ulMaxDebugSessions.x86=C4F2C
 bMultimonAllowed.x86  =C5010
 bFUSEnabled.x86       =C5014
-
 bInitialized.x64      =EB468
 bRemoteConnAllowed.x64=EB46C
 bMultimonAllowed.x64  =EB470
@@ -7219,7 +7143,6 @@ bRemoteConnAllowed.x86=C4F28
 ulMaxDebugSessions.x86=C4F2C
 bMultimonAllowed.x86  =C5010
 bFUSEnabled.x86       =C5014
-
 bInitialized.x64      =EB468
 bRemoteConnAllowed.x64=EB46C
 bMultimonAllowed.x64  =EB470
@@ -7238,7 +7161,6 @@ bRemoteConnAllowed.x86=C2F80
 bMultimonAllowed.x86  =C2F84
 ulMaxDebugSessions.x86=C2F88
 bFUSEnabled.x86       =C2F8C
-
 bServerSku.x64        =E83D8
 lMaxUserSessions.x64  =E83DC
 bAppServerAllowed.x64 =E83E0
@@ -7257,7 +7179,6 @@ bRemoteConnAllowed.x86=C2F80
 bMultimonAllowed.x86  =C2F84
 ulMaxDebugSessions.x86=C2F88
 bFUSEnabled.x86       =C2F8C
-
 bInitialized.x64      =E9468
 bRemoteConnAllowed.x64=E946C
 bMultimonAllowed.x64  =E9470
@@ -7276,7 +7197,6 @@ bRemoteConnAllowed.x86=C2F80
 bMultimonAllowed.x86  =C2F84
 ulMaxDebugSessions.x86=C2F88
 bFUSEnabled.x86       =C2F8C
-
 bInitialized.x64      =E9468
 bRemoteConnAllowed.x64=E946C
 bMultimonAllowed.x64  =E9470
@@ -7295,7 +7215,6 @@ bRemoteConnAllowed.x86=C2F80
 bMultimonAllowed.x86  =C2F84
 ulMaxDebugSessions.x86=C2F88
 bFUSEnabled.x86       =C2F8C
-
 bInitialized.x64      =E9468
 bRemoteConnAllowed.x64=E946C
 bMultimonAllowed.x64  =E9470
@@ -7314,7 +7233,6 @@ bRemoteConnAllowed.x86=C2F80
 bMultimonAllowed.x86  =C2F84
 ulMaxDebugSessions.x86=C2F88
 bFUSEnabled.x86       =C2F8C
-
 bInitialized.x64      =E9468
 bRemoteConnAllowed.x64=E946C
 bMultimonAllowed.x64  =E9470
@@ -7353,7 +7271,6 @@ bRemoteConnAllowed.x86=C3FA8
 bMultimonAllowed.x86  =C3FAC
 ulMaxDebugSessions.x86=C3FB0
 bFUSEnabled.x86       =C3FB4
-
 bInitialized.x64      =E9468
 bRemoteConnAllowed.x64=E946C
 bMultimonAllowed.x64  =E9470
@@ -7383,7 +7300,6 @@ bRemoteConnAllowed.x86=C7F7C
 bMultimonAllowed.x86  =C7F80
 ulMaxDebugSessions.x86=C7F84
 bFUSEnabled.x86       =C7F88
-
 bServerSku.x64        =E83D8
 lMaxUserSessions.x64  =E83DC
 bAppServerAllowed.x64 =E83E0
@@ -7402,7 +7318,6 @@ bRemoteConnAllowed.x86=C7F7C
 bMultimonAllowed.x86  =C7F80
 ulMaxDebugSessions.x86=C7F84
 bFUSEnabled.x86       =C7F88
-
 bServerSku.x64        =E83D8
 lMaxUserSessions.x64  =E83DC
 bAppServerAllowed.x64 =E83E0
@@ -7421,7 +7336,6 @@ bRemoteConnAllowed.x86=C8F84
 bMultimonAllowed.x86  =C8F88
 ulMaxDebugSessions.x86=C8F8C
 bFUSEnabled.x86       =C8F90
-
 bServerSku.x64        =E83E8
 lMaxUserSessions.x64  =E83EC
 bAppServerAllowed.x64 =E83F0
@@ -7440,7 +7354,6 @@ bRemoteConnAllowed.x86=C5F88
 bMultimonAllowed.x86  =C5F8C
 ulMaxDebugSessions.x86=C5F90
 bFUSEnabled.x86       =C5F94
-
 bServerSku.x64        =EA3E8
 lMaxUserSessions.x64  =EA3EC
 bAppServerAllowed.x64 =EA3F0
@@ -7459,7 +7372,6 @@ bRemoteConnAllowed.x86=C5F88
 bMultimonAllowed.x86  =C5F8C
 ulMaxDebugSessions.x86=C5F90
 bFUSEnabled.x86       =C5F94
-
 bServerSku.x64        =EA3E8
 lMaxUserSessions.x64  =EA3EC
 bAppServerAllowed.x64 =EA3F0
@@ -7478,7 +7390,6 @@ bRemoteConnAllowed.x86=C5F88
 bMultimonAllowed.x86  =C5F8C
 ulMaxDebugSessions.x86=C5F90
 bFUSEnabled.x86       =C5F94
-
 bServerSku.x64        =EB3EC
 lMaxUserSessions.x64  =EB3F0
 bAppServerAllowed.x64 =EB3F4
@@ -7497,7 +7408,6 @@ bRemoteConnAllowed.x86=C5F88
 bMultimonAllowed.x86  =C5F8C
 ulMaxDebugSessions.x86=C5F90
 bFUSEnabled.x86       =C5F94
-
 bServerSku.x64        =EB3EC
 lMaxUserSessions.x64  =EB3F0
 bAppServerAllowed.x64 =EB3F4
@@ -7516,7 +7426,6 @@ bRemoteConnAllowed.x86=C9F88
 bMultimonAllowed.x86  =C9F8C
 ulMaxDebugSessions.x86=C9F90
 bFUSEnabled.x86       =C9F94
-
 bServerSku.x64        =EB3EC
 lMaxUserSessions.x64  =EB3F0
 bAppServerAllowed.x64 =EB3F4
@@ -7535,7 +7444,6 @@ bRemoteConnAllowed.x86=C9F88
 bMultimonAllowed.x86  =C9F8C
 ulMaxDebugSessions.x86=C9F90
 bFUSEnabled.x86       =C9F94
-
 bServerSku.x64        =EB3EC
 lMaxUserSessions.x64  =EB3F0
 bAppServerAllowed.x64 =EB3F4
@@ -7554,7 +7462,6 @@ bRemoteConnAllowed.x86=C9F8C
 bMultimonAllowed.x86  =C9F90
 ulMaxDebugSessions.x86=C9F94
 bFUSEnabled.x86       =C9F98
-
 bServerSku.x64        =EB3F0
 lMaxUserSessions.x64  =EB3F4
 bAppServerAllowed.x64 =EB3F8
@@ -7573,7 +7480,6 @@ bRemoteConnAllowed.x86=C9F8C
 bMultimonAllowed.x86  =C9F90
 ulMaxDebugSessions.x86=C9F94
 bFUSEnabled.x86       =C9F98
-
 bServerSku.x64        =EB3F0
 lMaxUserSessions.x64  =EB3F4
 bAppServerAllowed.x64 =EB3F8
@@ -7592,7 +7498,6 @@ bRemoteConnAllowed.x86=C9F8C
 bMultimonAllowed.x86  =C9F90
 ulMaxDebugSessions.x86=C9F94
 bFUSEnabled.x86       =C9F98
-
 bServerSku.x64        =EB3F0
 lMaxUserSessions.x64  =EB3F4
 bAppServerAllowed.x64 =EB3F8
@@ -7611,7 +7516,6 @@ bRemoteConnAllowed.x86=C6F8C
 bMultimonAllowed.x86  =C6F90
 ulMaxDebugSessions.x86=C6F94
 bFUSEnabled.x86       =C6F98
-
 bServerSku.x64        =ED3E8
 lMaxUserSessions.x64  =ED3EC
 bAppServerAllowed.x64 =ED3F0
@@ -7630,7 +7534,6 @@ bRemoteConnAllowed.x86=C6F8C
 bMultimonAllowed.x86  =C6F90
 ulMaxDebugSessions.x86=C6F94
 bFUSEnabled.x86       =C6F98
-
 bServerSku.x64        =ED3E8
 lMaxUserSessions.x64  =ED3EC
 bAppServerAllowed.x64 =ED3F0
@@ -7649,7 +7552,6 @@ bRemoteConnAllowed.x86=C6F8C
 bMultimonAllowed.x86  =C6F90
 ulMaxDebugSessions.x86=C6F94
 bFUSEnabled.x86       =C6F98
-
 bServerSku.x64        =ED3E8
 lMaxUserSessions.x64  =ED3EC
 bAppServerAllowed.x64 =ED3F0
@@ -7668,7 +7570,6 @@ bRemoteConnAllowed.x86=C6F8C
 bMultimonAllowed.x86  =C6F90
 ulMaxDebugSessions.x86=C6F94
 bFUSEnabled.x86       =C6F98
-
 bServerSku.x64        =ED3E8
 lMaxUserSessions.x64  =ED3EC
 bAppServerAllowed.x64 =ED3F0
@@ -7687,7 +7588,6 @@ bRemoteConnAllowed.x86=C6F8C
 bMultimonAllowed.x86  =C6F90
 ulMaxDebugSessions.x86=C6F94
 bFUSEnabled.x86       =C6F98
-
 bServerSku.x64        =ED3E8
 lMaxUserSessions.x64  =ED3EC
 bAppServerAllowed.x64 =ED3F0
@@ -7706,7 +7606,6 @@ bRemoteConnAllowed.x86=C6F8C
 bMultimonAllowed.x86  =C6F90
 ulMaxDebugSessions.x86=C6F94
 bFUSEnabled.x86       =C6F98
-
 bServerSku.x64        =ED3E8
 lMaxUserSessions.x64  =ED3EC
 bAppServerAllowed.x64 =ED3F0
@@ -7725,7 +7624,6 @@ bRemoteConnAllowed.x86=C6F8C
 bMultimonAllowed.x86  =C6F90
 ulMaxDebugSessions.x86=C6F94
 bFUSEnabled.x86       =C6F98
-
 bServerSku.x64        =ED3E8
 lMaxUserSessions.x64  =ED3EC
 bAppServerAllowed.x64 =ED3F0
@@ -7744,7 +7642,6 @@ bRemoteConnAllowed.x86=C6F8C
 bMultimonAllowed.x86  =C6F90
 ulMaxDebugSessions.x86=C6F94
 bFUSEnabled.x86       =C6F98
-
 bServerSku.x64        =ED3E8
 lMaxUserSessions.x64  =ED3EC
 bAppServerAllowed.x64 =ED3F0
@@ -7763,7 +7660,6 @@ bRemoteConnAllowed.x86=C6F8C
 bMultimonAllowed.x86  =C6F90
 ulMaxDebugSessions.x86=C6F94
 bFUSEnabled.x86       =C6F98
-
 bServerSku.x64        =ED3E8
 lMaxUserSessions.x64  =ED3EC
 bAppServerAllowed.x64 =ED3F0
@@ -7782,7 +7678,6 @@ bRemoteConnAllowed.x86=C6F8C
 bMultimonAllowed.x86  =C6F90
 ulMaxDebugSessions.x86=C6F94
 bFUSEnabled.x86       =C6F98
-
 bServerSku.x64        =ED3E8
 lMaxUserSessions.x64  =ED3EC
 bAppServerAllowed.x64 =ED3F0
@@ -7801,7 +7696,6 @@ bRemoteConnAllowed.x86=C6F8C
 bMultimonAllowed.x86  =C6F90
 ulMaxDebugSessions.x86=C6F94
 bFUSEnabled.x86       =C6F98
-
 bServerSku.x64        =ED3E8
 lMaxUserSessions.x64  =ED3EC
 bAppServerAllowed.x64 =ED3F0
@@ -7820,7 +7714,6 @@ bRemoteConnAllowed.x86=C6F8C
 bMultimonAllowed.x86  =C6F90
 ulMaxDebugSessions.x86=C6F94
 bFUSEnabled.x86       =C6F98
-
 bServerSku.x64        =ED3E8
 lMaxUserSessions.x64  =ED3EC
 bAppServerAllowed.x64 =ED3F0
@@ -7839,7 +7732,6 @@ bRemoteConnAllowed.x86=C6F8C
 bMultimonAllowed.x86  =C6F90
 ulMaxDebugSessions.x86=C6F94
 bFUSEnabled.x86       =C6F98
-
 bServerSku.x64        =ED3E8
 lMaxUserSessions.x64  =ED3EC
 bAppServerAllowed.x64 =ED3F0
@@ -7858,7 +7750,6 @@ bRemoteConnAllowed.x86=C9EC8
 bMultimonAllowed.x86  =C9ECC
 ulMaxDebugSessions.x86=C9ED0
 bFUSEnabled.x86       =C9ED4
-
 bServerSku.x64        =EC2E8
 lMaxUserSessions.x64  =EC2EC
 bAppServerAllowed.x64 =EC2F0
@@ -7877,7 +7768,6 @@ bRemoteConnAllowed.x86=C9EC8
 bMultimonAllowed.x86  =C9ECC
 ulMaxDebugSessions.x86=C9ED0
 bFUSEnabled.x86       =C9ED4
-
 bServerSku.x64        =EC2E8
 lMaxUserSessions.x64  =EC2EC
 bAppServerAllowed.x64 =EC2F0
@@ -7896,7 +7786,6 @@ bRemoteConnAllowed.x86=C9EE8
 bMultimonAllowed.x86  =C9EEC
 ulMaxDebugSessions.x86=C9EF0
 bFUSEnabled.x86       =C9EF4
-
 bServerSku.x64        =EC2E8
 lMaxUserSessions.x64  =EC2EC
 bAppServerAllowed.x64 =EC2F0
@@ -7915,7 +7804,6 @@ bRemoteConnAllowed.x86=C9EE8
 bMultimonAllowed.x86  =C9EEC
 ulMaxDebugSessions.x86=C9EF0
 bFUSEnabled.x86       =C9EF4
-
 bServerSku.x64        =EC2E8
 lMaxUserSessions.x64  =EC2EC
 bAppServerAllowed.x64 =EC2F0
@@ -7934,7 +7822,6 @@ bRemoteConnAllowed.x86=CBF48
 bMultimonAllowed.x86  =CBF4C
 ulMaxDebugSessions.x86=CBF50
 bFUSEnabled.x86       =CBF54
-
 bServerSku.x64        =F1378
 lMaxUserSessions.x64  =F137C
 bAppServerAllowed.x64 =F1380
@@ -7953,7 +7840,6 @@ bRemoteConnAllowed.x86=CBF48
 bMultimonAllowed.x86  =CBF4C
 ulMaxDebugSessions.x86=CBF50
 bFUSEnabled.x86       =CBF54
-
 bServerSku.x64        =F1378
 lMaxUserSessions.x64  =F137C
 bAppServerAllowed.x64 =F1380
@@ -7972,7 +7858,6 @@ bRemoteConnAllowed.x86=CBF48
 bMultimonAllowed.x86  =CBF4C
 ulMaxDebugSessions.x86=CBF50
 bFUSEnabled.x86       =CBF54
-
 bServerSku.x64        =F1378
 lMaxUserSessions.x64  =F137C
 bAppServerAllowed.x64 =F1380
@@ -7991,7 +7876,6 @@ bRemoteConnAllowed.x86=CBF48
 bMultimonAllowed.x86  =CBF4C
 ulMaxDebugSessions.x86=CBF50
 bFUSEnabled.x86       =CBF54
-
 bServerSku.x64        =F1378
 lMaxUserSessions.x64  =F137C
 bAppServerAllowed.x64 =F1380
@@ -8010,7 +7894,6 @@ bRemoteConnAllowed.x86=CBF48
 bMultimonAllowed.x86  =CBF4C
 ulMaxDebugSessions.x86=CBF50
 bFUSEnabled.x86       =CBF54
-
 bServerSku.x64        =F1378
 lMaxUserSessions.x64  =F137C
 bAppServerAllowed.x64 =F1380
@@ -8029,7 +7912,6 @@ bRemoteConnAllowed.x86=CBF48
 bMultimonAllowed.x86  =CBF4C
 ulMaxDebugSessions.x86=CBF50
 bFUSEnabled.x86       =CBF54
-
 bServerSku.x64        =F1378
 lMaxUserSessions.x64  =F137C
 bAppServerAllowed.x64 =F1380
@@ -8048,7 +7930,6 @@ bRemoteConnAllowed.x86=CBF48
 bMultimonAllowed.x86  =CBF4C
 ulMaxDebugSessions.x86=CBF50
 bFUSEnabled.x86       =CBF54
-
 bServerSku.x64        =F1378
 lMaxUserSessions.x64  =F137C
 bAppServerAllowed.x64 =F1380
@@ -8107,7 +7988,6 @@ bRemoteConnAllowed.x86=CD7AC
 bMultimonAllowed.x86  =CD7B0
 ulMaxDebugSessions.x86=CD7B4
 bFUSEnabled.x86       =CD7B8
-
 bInitialized.x64      =ECAB0
 bServerSku.x64        =ECAB4
 lMaxUserSessions.x64  =ECAB8
@@ -8136,7 +8016,6 @@ bRemoteConnAllowed.x86=CD7AC
 bMultimonAllowed.x86  =CD7B0
 ulMaxDebugSessions.x86=CD7B4
 bFUSEnabled.x86       =CD7B8
-
 bInitialized.x64      =ECAB0
 bServerSku.x64        =ECAB4
 lMaxUserSessions.x64  =ECAB8
@@ -8155,7 +8034,6 @@ bRemoteConnAllowed.x86=CD7AC
 bMultimonAllowed.x86  =CD7B0
 ulMaxDebugSessions.x86=CD7B4
 bFUSEnabled.x86       =CD7B8
-
 bInitialized.x64 =ECAB0
 bServerSku.x64 =ECAB4
 lMaxUserSessions.x64 =ECAB8
@@ -8174,7 +8052,6 @@ bRemoteConnAllowed.x86=CD7AC
 bMultimonAllowed.x86  =CD7B0
 ulMaxDebugSessions.x86=CD7B4
 bFUSEnabled.x86       =CD7B8
-
 bInitialized.x64      =ECAB0
 bServerSku.x64        =ECAB4
 lMaxUserSessions.x64  =ECAB8
@@ -8193,7 +8070,6 @@ bRemoteConnAllowed.x86=CD7AC
 bMultimonAllowed.x86  =CD7B0
 ulMaxDebugSessions.x86=CD7B4
 bFUSEnabled.x86       =CD7B8
-
 bInitialized.x64      =ECAB0
 bServerSku.x64        =ECAB4
 lMaxUserSessions.x64  =ECAB8
@@ -8212,7 +8088,6 @@ bRemoteConnAllowed.x86=CD7AC
 bMultimonAllowed.x86  =CD7B0
 ulMaxDebugSessions.x86=CD7B4
 bFUSEnabled.x86       =CD7B8
-
 bInitialized.x64      =ECAB0
 bServerSku.x64        =ECAB4
 lMaxUserSessions.x64  =ECAB8
@@ -8231,7 +8106,6 @@ bRemoteConnAllowed.x86=CD7B0
 bMultimonAllowed.x86  =CD7B4
 ulMaxDebugSessions.x86=CD7B8
 bFUSEnabled.x86       =CD7BC
-
 bServerSku.x64        =ECAB8
 lMaxUserSessions.x64  =ECABC
 bAppServerAllowed.x64 =ECAC4
@@ -8250,7 +8124,6 @@ bRemoteConnAllowed.x86=CD7B0
 bMultimonAllowed.x86  =CD7B4
 ulMaxDebugSessions.x86=CD7B8
 bFUSEnabled.x86       =CD7BC
-
 bInitialized.x64      =ECAB4
 bServerSku.x64        =ECAB8
 lMaxUserSessions.x64  =ECABC
@@ -8269,7 +8142,6 @@ bRemoteConnAllowed.x86=D383C
 bMultimonAllowed.x86  =D3840
 ulMaxDebugSessions.x86=D3844
 bFUSEnabled.x86       =D3848
-
 bServerSku.x64        =F3B90
 lMaxUserSessions.x64  =F3B94
 bAppServerAllowed.x64 =F3B9C
@@ -8288,7 +8160,6 @@ bRemoteConnAllowed.x86=D183C
 bMultimonAllowed.x86  =D1840
 ulMaxDebugSessions.x86=D1844
 bFUSEnabled.x86       =D1848
-
 bInitialized.x64      =F3B8C
 bServerSku.x64        =F3B90
 lMaxUserSessions.x64  =F3B94
@@ -8303,7 +8174,6 @@ bInitialized.x64      =ECAB4
 bServerSku.x64        =ECAB8
 lMaxUserSessions.x64  =ECABC
 bAppServerAllowed.x64 =ECAC4
-
 bRemoteConnAllowed.x64=ECAC8
 bMultimonAllowed.x64  =ECACC
 ulMaxDebugSessions.x64=ECAD0
@@ -8390,7 +8260,6 @@ bRemoteConnAllowed.x86=D4790
 bMultimonAllowed.x86  =D4794
 ulMaxDebugSessions.x86=D4798
 bFUSEnabled.x86       =D479C
-
 bInitialized.x64      =F6A8C
 bServerSku.x64        =F6A90
 lMaxUserSessions.x64  =F6A94
@@ -8409,7 +8278,6 @@ bRemoteConnAllowed.x86=D5790
 bMultimonAllowed.x86  =D5794
 ulMaxDebugSessions.x86=D5798
 bFUSEnabled.x86       =D579C
-
 bInitialized.x64      =F6A8C
 bServerSku.x64        =F6A90
 lMaxUserSessions.x64  =F6A94
@@ -8428,7 +8296,6 @@ bRemoteConnAllowed.x86=D5790
 bMultimonAllowed.x86  =D5794
 ulMaxDebugSessions.x86=D5798
 bFUSEnabled.x86       =D579C
-
 bInitialized.x64      =F6A8C
 bServerSku.x64        =F6A90
 lMaxUserSessions.x64  =F6A94
@@ -8447,7 +8314,6 @@ bRemoteConnAllowed.x86=D5790
 bMultimonAllowed.x86  =D5794
 ulMaxDebugSessions.x86=D5798
 bFUSEnabled.x86       =D579C
-
 bInitialized.x64      =F6A8C
 bServerSku.x64        =F6A90
 lMaxUserSessions.x64  =F6A94
@@ -8466,7 +8332,6 @@ bRemoteConnAllowed.x86=D5790
 bMultimonAllowed.x86  =D5794
 ulMaxDebugSessions.x86=D5798
 bFUSEnabled.x86       =D579C
-
 bInitialized.x64      =F6A8C
 bServerSku.x64        =F6A90
 lMaxUserSessions.x64  =F6A94
@@ -8485,7 +8350,6 @@ bRemoteConnAllowed.x86=D3790
 bMultimonAllowed.x86  =D3794
 ulMaxDebugSessions.x86=D3798
 bFUSEnabled.x86       =D379C
-
 bInitialized.x64      =F6A8C
 bServerSku.x64        =F6A90
 lMaxUserSessions.x64  =F6A94
@@ -8554,7 +8418,6 @@ bRemoteConnAllowed.x86=CF938
 bMultimonAllowed.x86  =CF93C
 ulMaxDebugSessions.x86=CF940
 bFUSEnabled.x86       =CF944
-
 bInitialized.x64      =103FF8
 bServerSku.x64        =103FFC
 lMaxUserSessions.x64  =104000
@@ -8573,7 +8436,6 @@ bRemoteConnAllowed.x86=D196C
 bMultimonAllowed.x86  =D1970
 ulMaxDebugSessions.x86=D1974
 bFUSEnabled.x86       =D1978
-
 bInitialized.x64      =106028
 bServerSku.x64        =10602C
 lMaxUserSessions.x64  =106030
@@ -8592,7 +8454,6 @@ bRemoteConnAllowed.x86=D096C
 bMultimonAllowed.x86  =D0970
 ulMaxDebugSessions.x86=D0974
 bFUSEnabled.x86       =D0978
-
 bInitialized.x64      =106028
 bServerSku.x64        =10602C
 lMaxUserSessions.x64  =106030
@@ -8621,7 +8482,6 @@ bRemoteConnAllowed.x86=D096C
 bMultimonAllowed.x86  =D0970
 ulMaxDebugSessions.x86=D0974
 bFUSEnabled.x86       =D0978
-
 bInitialized.x64      =106028
 bServerSku.x64        =10602C
 lMaxUserSessions.x64  =106030
@@ -8650,7 +8510,6 @@ bRemoteConnAllowed.x86=D1A1C
 bMultimonAllowed.x86  =D1A20
 ulMaxDebugSessions.x86=D1A24
 bFUSEnabled.x86       =D1A28
-
 bInitialized.x64      =107108
 bServerSku.x64        =10710C
 lMaxUserSessions.x64  =107110

--- a/rdpwrap.ini
+++ b/rdpwrap.ini
@@ -1909,25 +1909,6 @@ SLInitHook.x64=1
 SLInitOffset.x64=22C80
 SLInitFunc.x64=New_CSLQuery_Initialize
 
-[10.0.14393.3503-SLInit]
-bInitialized.x86      =C2F94
-bServerSku.x86        =C2F98
-lMaxUserSessions.x86  =C2F9C
-bAppServerAllowed.x86 =C2FA0
-bRemoteConnAllowed.x86=C2FA4
-bMultimonAllowed.x86  =C2FA8
-ulMaxDebugSessions.x86=C2FAC
-bFUSEnabled.x86       =C2FB0
-
-bServerSku.x64        =E73D0
-lMaxUserSessions.x64  =E73D4
-bAppServerAllowed.x64 =E73D8
-bInitialized.x64      =E8470
-bRemoteConnAllowed.x64=E8474
-bMultimonAllowed.x64  =E8478
-ulMaxDebugSessions.x64=E847C
-bFUSEnabled.x64       =E8480
-
 [10.0.14393.3383]
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=A6578
@@ -2031,25 +2012,6 @@ SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=22C80
 SLInitFunc.x64=New_CSLQuery_Initialize
-
-[10.0.14393.3986-SLInit]
-bInitialized.x86 =C2F94
-bServerSku.x86 =C2F98
-lMaxUserSessions.x86 =C2F9C
-bAppServerAllowed.x86 =C2FA0
-bRemoteConnAllowed.x86=C2FA4
-bMultimonAllowed.x86 =C2FA8
-ulMaxDebugSessions.x86=C2FAC
-bFUSEnabled.x86 =C2FB0
-
-bServerSku.x64 =E73D0
-lMaxUserSessions.x64 =E73D4
-bAppServerAllowed.x64 =E73D8
-bInitialized.x64 =E8470
-bRemoteConnAllowed.x64=E8474
-bMultimonAllowed.x64 =E8478
-ulMaxDebugSessions.x64=E847C
-bFUSEnabled.x64 =E8480
 
 [10.0.14393.4169]
 LocalOnlyPatch.x86=1

--- a/rdpwrap.ini
+++ b/rdpwrap.ini
@@ -655,6 +655,18 @@ SLPolicyInternal.x64=1
 SLPolicyOffset.x64=21F90
 SLPolicyFunc.x64=New_Win8SL
 
+[6.2.9200.22977]
+; no x64-version
+SingleUserPatch.x86=1
+SingleUserOffset.x86=155B2
+SingleUserCode.x86=nop
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=13F68
+DefPolicyCode.x86=CDefPolicy_Query_eax_esi
+SLPolicyInternal.x86=1
+SLPolicyOffset.x86=195B9
+SLPolicyFunc.x86=New_Win8SL
+
 [6.2.9200.23509]
 ; new patch apply
 SingleUserPatch.x64=1
@@ -1149,16 +1161,43 @@ SLInitHook.x64=1
 SLInitOffset.x64=249D0
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[10.0.10240.18485]
+; no x64-version
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A8048
+LocalOnlyCode.x86=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=3B6DC
+SingleUserCode.x86=nop
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=2F699
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+SLInitHook.x86=1
+SLInitOffset.x86=3FA58
+SLInitFunc.x86=New_CSLQuery_Initialize
+
 [10.0.10240.18818]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A7818
+LocalOnlyCode.x86=jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=95E91
 LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=395BC
+SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=18274
 SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=3C629
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=0F0C5
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=44677
+SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=254F0
 SLInitFunc.x64=New_CSLQuery_Initialize
@@ -1844,7 +1883,78 @@ SLInitHook.x64=1
 SLInitOffset.x64=22C80
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[10.0.14393.3503]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A6528
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=8D931
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=36C65
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1B6A4
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=31189
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=F185
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=458A2
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22C80
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.14393.3503-SLInit]
+bInitialized.x86      =C2F94
+bServerSku.x86        =C2F98
+lMaxUserSessions.x86  =C2F9C
+bAppServerAllowed.x86 =C2FA0
+bRemoteConnAllowed.x86=C2FA4
+bMultimonAllowed.x86  =C2FA8
+ulMaxDebugSessions.x86=C2FAC
+bFUSEnabled.x86       =C2FB0
+
+bServerSku.x64        =E73D0
+lMaxUserSessions.x64  =E73D4
+bAppServerAllowed.x64 =E73D8
+bInitialized.x64      =E8470
+bRemoteConnAllowed.x64=E8474
+bMultimonAllowed.x64  =E8478
+ulMaxDebugSessions.x64=E847C
+bFUSEnabled.x64       =E8480
+
 [10.0.14393.3383]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A6578
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=8D8A1
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=36CE5
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1B6A4
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=31209
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=F185
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=45912
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=22C80
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.14393.3986]
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=A6578
 LocalOnlyCode.x86=jmpshort
@@ -1922,16 +2032,47 @@ SLInitHook.x64=1
 SLInitOffset.x64=22C80
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[10.0.14393.3986-SLInit]
+bInitialized.x86 =C2F94
+bServerSku.x86 =C2F98
+lMaxUserSessions.x86 =C2F9C
+bAppServerAllowed.x86 =C2FA0
+bRemoteConnAllowed.x86=C2FA4
+bMultimonAllowed.x86 =C2FA8
+ulMaxDebugSessions.x86=C2FAC
+bFUSEnabled.x86 =C2FB0
+
+bServerSku.x64 =E73D0
+lMaxUserSessions.x64 =E73D4
+bAppServerAllowed.x64 =E73D8
+bInitialized.x64 =E8470
+bRemoteConnAllowed.x64=E8474
+bMultimonAllowed.x64 =E8478
+ulMaxDebugSessions.x64=E847C
+bFUSEnabled.x64 =E8480
+
 [10.0.14393.4169]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=A5B28
+LocalOnlyCode.x86=jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=8CE51
 LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=398BC
+SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=25FA4
 SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=3C009
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=29825
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=3F752
+SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=0CA40
 SLInitFunc.x64=New_CSLQuery_Initialize
@@ -2744,6 +2885,21 @@ DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
 SLInitHook.x86=1
 SLInitOffset.x86=3F94D
 SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=2328C
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.15063.2283]
+; no x86-version
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=8CB21
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x64=1
+SingleUserOffset.x64=15EA4
+SingleUserCode.x64=Zero
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=FAE5
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
 SLInitHook.x64=1
 SLInitOffset.x64=2328C
 SLInitFunc.x64=New_CSLQuery_Initialize
@@ -3772,6 +3928,7 @@ LocalOnlyOffset.x64=77941
 LocalOnlyCode.x64=jmpshort
 SingleUserPatch.x64=1
 SingleUserOffset.x64=1322C
+; SingleUserOffset.x64=132F9
 SingleUserCode.x64=Zero
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=17F45
@@ -3837,24 +3994,28 @@ SLInitOffset.x64=1ABFC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.17763.292]
+; Patch CEnforcementCore::GetInstanceOfTSLicense
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=AFAD4
 LocalOnlyCode.x86=jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=77A11
 LocalOnlyCode.x64=jmpshort
+; Patch CSessionArbitrationHelper::IsSingleSessionPerUserEnabled
 SingleUserPatch.x86=1
 SingleUserOffset.x86=4D665
 SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=1322C
 SingleUserCode.x64=Zero
+; Patch CDefPolicy::Query
 DefPolicyPatch.x86=1
 DefPolicyOffset.x86=4BE69
 DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=17F45
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+; Hook CSLQuery::Initialize
 SLInitHook.x86=1
 SLInitOffset.x86=5B18A
 SLInitFunc.x86=New_CSLQuery_Initialize
@@ -3889,30 +4050,43 @@ SLInitOffset.x64=1ABFC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.17763.437]
+; Patch CEnforcementCore::GetInstanceOfTSLicense
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=AFE24
 LocalOnlyCode.x86=jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=77A41
 LocalOnlyCode.x64=jmpshort
+; Patch CSessionArbitrationHelper::IsSingleSessionPerUserEnabled
 SingleUserPatch.x86=1
 SingleUserOffset.x86=4D7B5
 SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=1339C
+; SingleUserOffset.x64=1322C
 SingleUserCode.x64=Zero
+; Patch CDefPolicy::Query
 DefPolicyPatch.x86=1
 DefPolicyOffset.x86=4BFB9
 DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=18025
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+; Hook CSLQuery::Initialize
 SLInitHook.x86=1
 SLInitOffset.x86=5B2CA
 SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=1ACDC
 SLInitFunc.x64=New_CSLQuery_Initialize
+bInitialized.x64 =ECAB0
+bServerSku.x64 =ECAB4
+lMaxUserSessions.x64 =ECAB8
+bAppServerAllowed.x64 =ECAC0
+bRemoteConnAllowed.x64=ECAC4
+bMultimonAllowed.x64 =ECAC8
+ulMaxDebugSessions.x64=ECACC
+bFUSEnabled.x64 =ECAD0
 
 [10.0.17763.771]
 LocalOnlyPatch.x86=1
@@ -3941,11 +4115,24 @@ SLInitOffset.x64=1ACDC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.17763.1369]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=AFEB4
+LocalOnlyCode.x86=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=4D7F5
+SingleUserCode.x86=nop
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=4BFF9
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+SLInitHook.x86=1
+SLInitOffset.x86=5B30A
+SLInitFunc.x86=New_CSLQuery_Initialize
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=77AD1
 LocalOnlyCode.x64=jmpshort
 SingleUserPatch.x64=1
 SingleUserOffset.x64=13469
+; SingleUserOffset.x64=1339C
 SingleUserCode.x64=Zero
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=18025
@@ -3954,19 +4141,58 @@ SLInitHook.x64=1
 SLInitOffset.x64=1ACDC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[10.0.17763.1613]
+LocalOnlyPatch.x86 =1
+LocalOnlyOffset.x86 =B5834
+LocalOnlyCode.x86 =jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=7E381
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86 =1
+SingleUserOffset.x86=4EC35
+SingleUserCode.x86 =nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1386C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86 =1
+DefPolicyOffset.x86 =4D439
+DefPolicyCode.x86 =CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=184F5
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86 =1
+SLInitOffset.x86 =61A0A
+SLInitFunc.x86 =New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=2198C
+SLInitFunc.x64=New_CSLQuery_Initialize
+
 [10.0.17763.1697]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B4584
+LocalOnlyCode.x86=jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=7E421
 LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=4EF55
+SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=13989
+; SingleUserOffset.x64=138BC
 SingleUserCode.x64=Zero
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=18545
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=4D5D9
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 SLInitHook.x64=1
 SLInitOffset.x64=21A3C
 SLInitFunc.x64=New_CSLQuery_Initialize
+SLInitHook.x86=1
+SLInitOffset.x86=61C6A
+SLInitFunc.x86=New_CSLQuery_Initialize
 
 [10.0.17763.1971]
 LocalOnlyPatch.x64=1
@@ -4098,6 +4324,7 @@ SingleUserOffset.x86=50515
 SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=0DBFC
+; SingleUserOffset.x64=0DDC9
 SingleUserCode.x64=Zero
 DefPolicyPatch.x86=1
 DefPolicyOffset.x86=50249
@@ -4165,44 +4392,80 @@ SLInitOffset.x64=22DDC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.18362.657]
-
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B7D06
+LocalOnlyCode.x86=jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=82FB5
 LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=50535
+SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=0DBFC
 SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=50269
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=1FE15
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5A77A
+SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=22DDC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.18362.836]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B7D06
+LocalOnlyCode.x86=jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=82FC5
 LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=50515
+SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=0DBFC
 SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=50249
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=1FE15
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5A75A
+SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=22DDC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.18362.1316]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B67C6
+LocalOnlyCode.x86=jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=83075
 LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=35735
+SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=0DD19
+; SingleUserOffset.x64=0DC4C
 SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=4D679
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=1FE65
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=5C18A
+SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=22E9C
 SLInitFunc.x64=New_CSLQuery_Initialize
@@ -4263,6 +4526,20 @@ SLInitHook.x64=1
 SLInitOffset.x64=2730C
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[10.0.18362.1533]
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=83075
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x64=1
+SingleUserOffset.x64=0DC4C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=1FE65
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x64=1
+SLInitOffset.x64=22E9C
+SLInitFunc.x64=New_CSLQuery_Initialize
+
 [10.0.19041.1]
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=87611
@@ -4281,12 +4558,21 @@ SLInitFunc.x64=New_CSLQuery_Initialize
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=B46B9
 LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=87611
+LocalOnlyCode.x64=jmpshort
 SingleUserPatch.x86=1
 SingleUserOffset.x86=3AD27
 SingleUserCode.x86=Zero
+SingleUserPatch.x64=1
+SingleUserOffset.x64=0BF0C
+SingleUserCode.x64=Zero
 DefPolicyPatch.x86=1
 DefPolicyOffset.x86=3D7D9
 DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=17ED5
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
 SLInitHook.x86=1
 SLInitOffset.x86=66658
 SLInitFunc.x86=New_CSLQuery_Initialize
@@ -4304,32 +4590,58 @@ SLInitOffset.x64=1BDFC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.19041.662]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B5F59
+LocalOnlyCode.x86=jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=88E81
 LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=3BC05
+SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=0CAE2
+; SingleUserOffset.x64=0CA0C
 SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=3E779
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=189D5
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=68068
+SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=1D50C
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.19041.746]
+LocalOnlyPatch.x86 =1
+LocalOnlyOffset.x86 =B5979
+LocalOnlyCode.x86 =jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=88F31
 LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86 =1
+SingleUserOffset.x86=3BC05
+SingleUserCode.x86 =nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=0CB22
+; SingleUserOffset.x64=0CA4C
 SingleUserCode.x64=Zero
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=18A15
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+DefPolicyPatch.x86 =1
+DefPolicyOffset.x86 =3E779
+DefPolicyCode.x86 =CDefPolicy_Query_eax_ecx
 SLInitHook.x64=1
 SLInitOffset.x64=1D5BC
 SLInitFunc.x64=New_CSLQuery_Initialize
+SLInitHook.x86 =1
+SLInitOffset.x86 =67B9A
+SLInitFunc.x86 =New_CSLQuery_Initialize
 
 [10.0.19041.782]
 LocalOnlyPatch.x64=1
@@ -4346,15 +4658,27 @@ SLInitOffset.x64=1D5BC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.19041.789]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B59D9
+LocalOnlyCode.x86=jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=88F41
 LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=3BC45
+SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=0CA4C
 SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=3E7C9
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=18A15
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=67BF8
+SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=1D5BC
 SLInitFunc.x64=New_CSLQuery_Initialize
@@ -4374,15 +4698,28 @@ SLInitOffset.x64=1E29C
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.19041.964]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B65C9
+LocalOnlyCode.x86=jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=89F31
 LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=3BD35
+SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=0CB22
+; SingleUserOffset.x64=0CA4C
 SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=3E8A9
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=18A15
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=687F8
+SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=1E29C
 SLInitFunc.x64=New_CSLQuery_Initialize
@@ -4614,6 +4951,7 @@ DefPolicyPatch.x64=1
 DefPolicyOffset.x64=17B85
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
 SLInitHook.x64=1
+; SLInitOffset.x64=226B0
 SLInitOffset.x64=1AE5C
 SLInitFunc.x64=New_CSLQuery_Initialize
 
@@ -5753,7 +6091,6 @@ bServerSku.x64        =EDC04
 ulMaxDebugSessions.x64=EDC08
 bRemoteConnAllowed.x64=EDC0C
 
-
 [10.0.9926.0-SLInit]
 bFUSEnabled.x86       =C17D8
 lMaxUserSessions.x86  =C17DC
@@ -5850,7 +6187,27 @@ bMultimonAllowed.x64  =F3468
 ulMaxDebugSessions.x64=F346C
 bRemoteConnAllowed.x64=F3470
 
+[10.0.10240.18485-SLInit]
+; no x64-version
+bFUSEnabled.x86       =C4F88
+lMaxUserSessions.x86  =C4F8C
+bAppServerAllowed.x86 =C4F90
+bInitialized.x86      =C4F94
+bMultimonAllowed.x86  =C4F98
+bServerSku.x86        =C4F9C
+ulMaxDebugSessions.x86=C4FA0
+bRemoteConnAllowed.x86=C4FA4
+
 [10.0.10240.18818-SLInit]
+bInitialized.x86      =C3F94
+bServerSku.x86        =C3F9C
+lMaxUserSessions.x86  =C3F8C
+bAppServerAllowed.x86 =C3F90
+bRemoteConnAllowed.x86=C3FA4
+bMultimonAllowed.x86  =C3F98
+ulMaxDebugSessions.x86=C3FA0
+bFUSEnabled.x86       =C3F88
+
 lMaxUserSessions.x64  =F13B0
 bAppServerAllowed.x64 =F13B4
 bServerSku.x64        =F13B8
@@ -6414,15 +6771,43 @@ bMultimonAllowed.x64  =E8478
 ulMaxDebugSessions.x64=E847C
 bFUSEnabled.x64       =E8480
 
+[10.0.14393.3986-SLInit]
+bInitialized.x86      =C2F94
+bServerSku.x86        =C2F98
+lMaxUserSessions.x86  =C2F9C
+bAppServerAllowed.x86 =C2FA0
+bRemoteConnAllowed.x86=C2FA4
+bMultimonAllowed.x86  =C2FA8
+ulMaxDebugSessions.x86=C2FAC
+bFUSEnabled.x86       =C2FB0
+
+bServerSku.x64        =E73D0
+lMaxUserSessions.x64  =E73D4
+bAppServerAllowed.x64 =E73D8
+bInitialized.x64      =E8470
+bRemoteConnAllowed.x64=E8474
+bMultimonAllowed.x64  =E8478
+ulMaxDebugSessions.x64=E847C
+bFUSEnabled.x64       =E8480
+
 [10.0.14393.4169-SLInit]
-bServerSku.x64        =0E63D0
-lMaxUserSessions.x64  =0E63D4
-bAppServerAllowed.x64 =0E63D8
-bInitialized.x64      =0E7470
-bRemoteConnAllowed.x64=0E7474
-bMultimonAllowed.x64  =0E7478
-ulMaxDebugSessions.x64=0E747C
-bFUSEnabled.x64       =0E7480
+bInitialized.x86      =C1F94
+bServerSku.x86        =C1F98
+lMaxUserSessions.x86  =C1F9C
+bAppServerAllowed.x86 =C1FA0
+bRemoteConnAllowed.x86=C1FA4
+bMultimonAllowed.x86  =C1FA8
+ulMaxDebugSessions.x86=C1FAC
+bFUSEnabled.x86       =C1FB0
+
+bServerSku.x64        =E63D0
+lMaxUserSessions.x64  =E63D4
+bAppServerAllowed.x64 =E63D8
+bInitialized.x64      =E7470
+bRemoteConnAllowed.x64=E7474
+bMultimonAllowed.x64  =E7478
+ulMaxDebugSessions.x64=E747C
+bFUSEnabled.x64       =E7480
 
 [10.0.14393.4704-SLInit]
 bInitialized.x64      =E7470
@@ -6997,8 +7382,6 @@ bServerSku.x64        =E9484
 lMaxUserSessions.x64  =E9488
 bAppServerAllowed.x64 =E948C
 
-
-
 [10.0.15063.1746-SLInit]
 bInitialized.x86      =C3F98
 bServerSku.x86        =C3F9C
@@ -7018,6 +7401,16 @@ bServerSku.x64        =E9484
 lMaxUserSessions.x64  =E9488
 bAppServerAllowed.x64 =E948C
 
+[10.0.15063.2283-SLInit]
+; no x86-version
+bInitialized.x64      =E9468
+bRemoteConnAllowed.x64=E946C
+bMultimonAllowed.x64  =E9470
+ulMaxDebugSessions.x64=E9474
+bFUSEnabled.x64       =E9478
+bServerSku.x64        =E9484
+lMaxUserSessions.x64  =E9488
+bAppServerAllowed.x64 =E948C
 
 [10.0.16179.1000-SLInit]
 bInitialized.x86      =C7F6C
@@ -7819,8 +8212,8 @@ bRemoteConnAllowed.x86=CD7AC
 bMultimonAllowed.x86  =CD7B0
 ulMaxDebugSessions.x86=CD7B4
 bFUSEnabled.x86       =CD7B8
-bInitialized.x64      =ECAB0
 
+bInitialized.x64      =ECAB0
 bServerSku.x64        =ECAB4
 lMaxUserSessions.x64  =ECAB8
 bAppServerAllowed.x64 =ECAC0
@@ -7877,31 +8270,78 @@ bMultimonAllowed.x86  =CD7B4
 ulMaxDebugSessions.x86=CD7B8
 bFUSEnabled.x86       =CD7BC
 
+bServerSku.x64        =ECAB8
+lMaxUserSessions.x64  =ECABC
+bAppServerAllowed.x64 =ECAC4
+bInitialized.x64      =ECAB4
+bRemoteConnAllowed.x64=ECAC8
+bMultimonAllowed.x64  =ECACC
+ulMaxDebugSessions.x64=ECAD0
+bFUSEnabled.x64       =ECAD4
+
 [10.0.17763.1369-SLInit]
-bInitialized.x64      =0ECAB4
-bServerSku.x64        =0ECAB8
-lMaxUserSessions.x64  =0ECABC
-bAppServerAllowed.x64 =0ECAC4
-bRemoteConnAllowed.x64=0ECAC8
-bMultimonAllowed.x64  =0ECACC
-ulMaxDebugSessions.x64=0ECAD0
-bFUSEnabled.x64       =0ECAD4
+bInitialized.x86      =CD79C
+bServerSku.x86        =CD7A0
+lMaxUserSessions.x86  =CD7A4
+bAppServerAllowed.x86 =CD7AC
+bRemoteConnAllowed.x86=CD7B0
+bMultimonAllowed.x86  =CD7B4
+ulMaxDebugSessions.x86=CD7B8
+bFUSEnabled.x86       =CD7BC
+
+bInitialized.x64      =ECAB4
+bServerSku.x64        =ECAB8
+lMaxUserSessions.x64  =ECABC
+bAppServerAllowed.x64 =ECAC4
+bRemoteConnAllowed.x64=ECAC8
+bMultimonAllowed.x64  =ECACC
+ulMaxDebugSessions.x64=ECAD0
+bFUSEnabled.x64       =ECAD4
+
+[10.0.17763.1613-SLInit]
+bInitialized.x86      =D3828
+bServerSku.x86        =D382C
+lMaxUserSessions.x86  =D3830
+bAppServerAllowed.x86 =D3838
+bRemoteConnAllowed.x86=D383C
+bMultimonAllowed.x86  =D3840
+ulMaxDebugSessions.x86=D3844
+bFUSEnabled.x86       =D3848
+
+bServerSku.x64        =F3B90
+lMaxUserSessions.x64  =F3B94
+bAppServerAllowed.x64 =F3B9C
+bInitialized.x64      =F3B8C
+bRemoteConnAllowed.x64=F3BA0
+bMultimonAllowed.x64  =F3BA4
+ulMaxDebugSessions.x64=F3BA8
+bFUSEnabled.x64       =F3BAC
 
 [10.0.17763.1697-SLInit]
-bInitialized.x64      =0F3B8C
-bServerSku.x64        =0F3B90
-lMaxUserSessions.x64  =0F3B94
-bAppServerAllowed.x64 =0F3B9C
-bRemoteConnAllowed.x64=0F3BA0
-bMultimonAllowed.x64  =0F3BA4
-ulMaxDebugSessions.x64=0F3BA8
-bFUSEnabled.x64       =0F3BAC
+bInitialized.x86      =D1828
+bServerSku.x86        =D182C
+lMaxUserSessions.x86  =D1830
+bAppServerAllowed.x86 =D1838
+bRemoteConnAllowed.x86=D183C
+bMultimonAllowed.x86  =D1840
+ulMaxDebugSessions.x86=D1844
+bFUSEnabled.x86       =D1848
+
+bInitialized.x64      =F3B8C
+bServerSku.x64        =F3B90
+lMaxUserSessions.x64  =F3B94
+bAppServerAllowed.x64 =F3B9C
+bRemoteConnAllowed.x64=F3BA0
+bMultimonAllowed.x64  =F3BA4
+ulMaxDebugSessions.x64=F3BA8
+bFUSEnabled.x64       =F3BAC
 
 [10.0.17763.1971-SLInit]
 bInitialized.x64      =ECAB4
 bServerSku.x64        =ECAB8
 lMaxUserSessions.x64  =ECABC
 bAppServerAllowed.x64 =ECAC4
+
 bRemoteConnAllowed.x64=ECAC8
 bMultimonAllowed.x64  =ECACC
 ulMaxDebugSessions.x64=ECAD0
@@ -8037,6 +8477,15 @@ ulMaxDebugSessions.x64=F6AA8
 bFUSEnabled.x64       =F6AAC
 
 [10.0.18362.657-SLInit]
+bInitialized.x86      =D577C
+bServerSku.x86        =D5780
+lMaxUserSessions.x86  =D5784
+bAppServerAllowed.x86 =D578C
+bRemoteConnAllowed.x86=D5790
+bMultimonAllowed.x86  =D5794
+ulMaxDebugSessions.x86=D5798
+bFUSEnabled.x86       =D579C
+
 bInitialized.x64      =F6A8C
 bServerSku.x64        =F6A90
 lMaxUserSessions.x64  =F6A94
@@ -8047,6 +8496,15 @@ ulMaxDebugSessions.x64=F6AA8
 bFUSEnabled.x64       =F6AAC
 
 [10.0.18362.836-SLInit]
+bInitialized.x86      =D577C
+bServerSku.x86        =D5780
+lMaxUserSessions.x86  =D5784
+bAppServerAllowed.x86 =D578C
+bRemoteConnAllowed.x86=D5790
+bMultimonAllowed.x86  =D5794
+ulMaxDebugSessions.x86=D5798
+bFUSEnabled.x86       =D579C
+
 bInitialized.x64      =F6A8C
 bServerSku.x64        =F6A90
 lMaxUserSessions.x64  =F6A94
@@ -8057,14 +8515,23 @@ ulMaxDebugSessions.x64=F6AA8
 bFUSEnabled.x64       =F6AAC
 
 [10.0.18362.1316-SLInit]
-bInitialized.x64      =0F6A8C
-bServerSku.x64        =0F6A90
-lMaxUserSessions.x64  =0F6A94
-bAppServerAllowed.x64 =0F6A9C
-bRemoteConnAllowed.x64=0F6AA0
-bMultimonAllowed.x64  =0F6AA4
-ulMaxDebugSessions.x64=0F6AA8
-bFUSEnabled.x64       =0F6AAC
+bInitialized.x86      =D377C
+bServerSku.x86        =D3780
+lMaxUserSessions.x86  =D3784
+bAppServerAllowed.x86 =D378C
+bRemoteConnAllowed.x86=D3790
+bMultimonAllowed.x86  =D3794
+ulMaxDebugSessions.x86=D3798
+bFUSEnabled.x86       =D379C
+
+bInitialized.x64      =F6A8C
+bServerSku.x64        =F6A90
+lMaxUserSessions.x64  =F6A94
+bAppServerAllowed.x64 =F6A9C
+bRemoteConnAllowed.x64=F6AA0
+bMultimonAllowed.x64  =F6AA4
+ulMaxDebugSessions.x64=F6AA8
+bFUSEnabled.x64       =F6AAC
 
 [10.0.18362.1533-SLInit]
 bInitialized.x64      =F6A8C
@@ -8125,6 +8592,7 @@ bRemoteConnAllowed.x86=CF938
 bMultimonAllowed.x86  =CF93C
 ulMaxDebugSessions.x86=CF940
 bFUSEnabled.x86       =CF944
+
 bInitialized.x64      =103FF8
 bServerSku.x64        =103FFC
 lMaxUserSessions.x64  =104000
@@ -8135,6 +8603,15 @@ ulMaxDebugSessions.x64=104018
 bFUSEnabled.x64       =10401C
 
 [10.0.19041.662-SLInit]
+bInitialized.x86      =D1954
+bServerSku.x86        =D1958
+lMaxUserSessions.x86  =D195C
+bAppServerAllowed.x86 =D1964
+bRemoteConnAllowed.x86=D196C
+bMultimonAllowed.x86  =D1970
+ulMaxDebugSessions.x86=D1974
+bFUSEnabled.x86       =D1978
+
 bInitialized.x64      =106028
 bServerSku.x64        =10602C
 lMaxUserSessions.x64  =106030
@@ -8145,6 +8622,15 @@ ulMaxDebugSessions.x64=106048
 bFUSEnabled.x64       =10604C
 
 [10.0.19041.746-SLInit]
+bInitialized.x86      =D0954
+bServerSku.x86        =D0958
+lMaxUserSessions.x86  =D095C
+bAppServerAllowed.x86 =D0964
+bRemoteConnAllowed.x86=D096C
+bMultimonAllowed.x86  =D0970
+ulMaxDebugSessions.x86=D0974
+bFUSEnabled.x86       =D0978
+
 bInitialized.x64      =106028
 bServerSku.x64        =10602C
 lMaxUserSessions.x64  =106030
@@ -8165,6 +8651,15 @@ ulMaxDebugSessions.x64=106048
 bFUSEnabled.x64       =10604C
 
 [10.0.19041.789-SLInit]
+bInitialized.x86      =D0954
+bServerSku.x86        =D0958
+lMaxUserSessions.x86  =D095C
+bAppServerAllowed.x86 =D0964
+bRemoteConnAllowed.x86=D096C
+bMultimonAllowed.x86  =D0970
+ulMaxDebugSessions.x86=D0974
+bFUSEnabled.x86       =D0978
+
 bInitialized.x64      =106028
 bServerSku.x64        =10602C
 lMaxUserSessions.x64  =106030
@@ -8185,6 +8680,15 @@ ulMaxDebugSessions.x64=107128
 bFUSEnabled.x64       =10712C
 
 [10.0.19041.964-SLInit]
+bInitialized.x86      =D1A04
+bServerSku.x86        =D1A08
+lMaxUserSessions.x86  =D1A0C
+bAppServerAllowed.x86 =D1A14
+bRemoteConnAllowed.x86=D1A1C
+bMultimonAllowed.x86  =D1A20
+ulMaxDebugSessions.x86=D1A24
+bFUSEnabled.x86       =D1A28
+
 bInitialized.x64      =107108
 bServerSku.x64        =10710C
 lMaxUserSessions.x64  =107110


### PR DESCRIPTION
Hi there, thanks for maintaining the `ini` file! :D

Since I've merged the changes with the version I'm maintaining, I thought I'd ask you to merge some of the missing sections that exist in the version I already have.

Please review, and if something is useless, let me know so I can delete them.  
There are a couple of alternative values that I've commented out.

Additionally, I've cleaned up a couple of whitespace, and trimmed the values, which will be fixed if this PR is accepted.

## List of changes

### Missing builds
(The '✔️' mark means added, '🚫' means non-existant, empty means it were already in your `ini` file)

| name               | x86 | x64 |
| ------------------ | --- | --- |
| `6.2.9200.22977`   | ✔️   | 🚫  |
| `10.0.10240.18485` | ✔️   | 🚫  |
| `10.0.10240.18818` | ✔️   |     |
| `10.0.14393.3503`  | ✔️   | ✔️   |
| `10.0.14393.3986`  | ✔️   | ✔️   |
| `10.0.14393.4169`  | ✔️   |     |
| `10.0.15063.2283`  | 🚫  | ✔️   |
| `10.0.17763.1369`  | ✔️   |     |
| `10.0.17763.1613`  | ✔️   | ✔️   |
| `10.0.17763.1697`  | ✔️   |     |
| `10.0.18362.657`   | ✔️   |     |
| `10.0.18362.836`   | ✔️   |     |
| `10.0.18362.1316`  | ✔️   |     |
| `10.0.18362.1533`  | ?   | ✔️   |
| `10.0.19041.1`     |     | ✔️   |
| `10.0.19041.662`   | ✔️   |     |
| `10.0.19041.746`   | ✔️   |     |
| `10.0.19041.789`   | ✔️   |     |
| `10.0.19041.964`   | ✔️   |     |

### Alternative values
(These alternative values were added as a commented out line)

| name              | key                    | your value | alternative value |
| ----------------- | ---------------------- | ---------- | ----------------- |
| `10.0.17763.1369` | `SingleUserOffset.x64` | `13469`    | `1339C`           |
| `10.0.17763.1697` | `SingleUserOffset.x64` | `13989`    | `138BC`           |
| `10.0.17763.1971` | `SingleUserOffset.x64` | `0DBFC`    | `0DDC9`           |
| `10.0.18362.1316` | `SingleUserOffset.x64` | `0DD19`    | `0DC4C`           |
| `10.0.19041.662`  | `SingleUserOffset.x64` | `0CAE2`    | `0CA0C`           |
| `10.0.19041.746`  | `SingleUserOffset.x64` | `0CB22`    | `0CA4C`           |
| `10.0.19041.964`  | `SingleUserOffset.x64` | `0CB22`    | `0CA4C`           |
| `10.0.19041.964`  | `SLInitOffset.x64`     | `1AE5C`    | `226B0`           |

### Misc
(No real changes to values, just being a Perfectionist)

- `10.0.17763.292`: added missing comments that were present in my `ini` file
- `10.0.17763.437`: added missing comments that were present in my `ini` file
- `10.0.18362.657`: removed blank line after label
- `10.0.9926.0-SLInit`: removed blank line before label
- `10.0.15063.1746-SLInit`: removed two blank lines before label
- `10.0.16179.1000-SLInit`: moved a blank line separating the x86 and x64 sections
- `10.0.17763.1971-SLInit`: added a blank line separating the x86 and x64 sections
- `10.0.18362.1316-SLInit`: trimmed the leading `0` from the hex values
- `10.0.18362.1533-SLInit`: added a blank line separating the x86 and x64 sections

These issues were mostly present in the original file, so I'd very much appreciate it if you could merge this PR, if there are no side effects in doing so.

Please let me know,
thanks!
