### PR TITLE
Update rdpwrap.ini

### DIFF
--- a/rdpwrap.ini
+++ b/rdpwrap.ini
@@ -3,7 +3,7 @@
 ; Edited by sebaxakerhtc
 
 [Main]
-Updated=2026-06-24
+Updated=2026-07-31
 LogFile=\rdpwrap.txt
 SLPolicyHookNT60=1
 SLPolicyHookNT61=1
@@ -20937,3 +20937,29 @@ bMultimonAllowed.x64=12EBC0
 lMaxUserSessions.x64=12EBA8
 ulMaxDebugSessions.x64=12EBC8
 bInitialized.x64=12EBA0
+
+[10.0.17763.9020-SLInit]
+bServerSku.x64 =11C26C
+bRemoteConnAllowed.x64=11C27C
+bFUSEnabled.x64 =11C288
+bAppServerAllowed.x64 =11C278
+bMultimonAllowed.x64 =11C280
+lMaxUserSessions.x64 =11C270
+ulMaxDebugSessions.x64=11C284
+bInitialized.x64 =11C268
+
+[10.0.17763.9020]
+; no x86 section
+
+LocalOnlyPatch.x64 =1
+LocalOnlyOffset.x64 =8E111
+LocalOnlyCode.x64 =jmpshort
+SingleUserPatch.x64 =1
+SingleUserOffset.x64 =16F62
+SingleUserCode.x64 =mov_eax_1_nop_1
+DefPolicyPatch.x64 =1
+DefPolicyOffset.x64 =20435
+DefPolicyCode.x64 =CDefPolicy_Query_eax_rcx
+SLInitHook.x64 =1
+SLInitOffset.x64 =2FF3C
+SLInitFunc.x64 =New_CSLQuery_Initialize


### PR DESCRIPTION
Add support for 10.0.17763.9020

## Added support for termsrv.dll version 10.0.17763.9020

### Details
- **Version:** 10.0.17763.9020
- **SHA-256:** 43179EE9270987FD4691E458A394C6B4EF44D140039A679CE95A8AB0BB90B929
- **Tested with:** RDP Wrapper v1.6.2

### Changes
1. Updated `[PatchCodes]` with `mov_eax_1_nop_1`
2. Added `[10.0.17763.9020]` section
3. Added `[10.0.17763.9020-SLInit]` section

### Notes
- Only x64 section included (no x86)
- Offsets confirmed working

### References
- GitHub Issue #4338: https://github.com/stascorp/rdpwrap/issues/4338

Fixes #4338